### PR TITLE
Modify interaction with juju to use libjuju

### DIFF
--- a/sunbeam/commands/microk8s.py
+++ b/sunbeam/commands/microk8s.py
@@ -105,6 +105,28 @@ class EnableDNS(BaseCoreMicroK8sEnableStep):
     def __init__(self):
         super().__init__("dns")
 
+    def has_prompts(self) -> bool:
+        return True
+
+    def prompt(self, console: Optional["rich.console.Console"] = None) -> None:
+        """Prompt the user for usptream nameserver.
+
+        Prompts the user to determine the upstream nameserver to be used
+        to configure dns.
+
+        :param console: the console to prompt on
+        :type console: rich.console.Console (Optional)
+        """
+        from rich.prompt import Prompt
+
+        console.print()
+        nameservers = Prompt.ask(
+            "Comma separated upstream nameservers:",
+            default="8.8.8.8,8.8.4.4",
+            console=console,
+        )
+        self._args = [nameservers]
+
 
 class EnableStorage(BaseCoreMicroK8sEnableStep):
     """Enable host-based storage for microk8s"""

--- a/sunbeam/commands/reset.py
+++ b/sunbeam/commands/reset.py
@@ -35,7 +35,7 @@ def reset() -> None:
     Reset the node to the defaults.
     TODO:
     Single node:
-    microk8s destroy-model sunbeam
+    microk8s destroy-model openstack
     snap remove microk8s??
     snap remove juju??
     Multi node:
@@ -46,8 +46,7 @@ def reset() -> None:
     role = snap.config.get("node.role")
     node_role = Role[role.upper()]
 
-    # FIXME: Below params should be snap config options??
-    model = "sunbeam"
+    model = snap.config.get("control-plane.model")
 
     plan = []
 

--- a/sunbeam/commands/status.py
+++ b/sunbeam/commands/status.py
@@ -81,7 +81,7 @@ def status(wait_ready: bool, timeout: int) -> None:
             console.print(f"{message}[red]Failed[/red]")
             raise click.ClickException(result.message)
 
-    console.print("Sunbeam status:")
+    console.print("Microstack status:")
     for message in status_overall:
         if "active" in message:
             console.print(f"[green]{message}[/green]")


### PR DESCRIPTION
Status command uses zaza library earlier.
Now it is changed to libjuju to ensure
deploymodel works with [1]

Also change other interactions with juju to use lib-juju instead of cli.
This is not applicable for bootstrap as this functionality is
missing in libjuju.

[1] git+https://github.com/wolsen/python-libjuju@update-3.0-schema#egg=juju